### PR TITLE
Audio Visibility

### DIFF
--- a/server/src/Audiochan.Core/Common/Builders/AudioBuilder.cs
+++ b/server/src/Audiochan.Core/Common/Builders/AudioBuilder.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Audiochan.Core.Common.Extensions;
 using Audiochan.Core.Common.Helpers;
 using Audiochan.Core.Entities;
+using Audiochan.Core.Entities.Enums;
 using Audiochan.Core.Features.Audios.CreateAudio;
 
 namespace Audiochan.Core.Common.Builders
@@ -44,7 +45,7 @@ namespace Audiochan.Core.Common.Builders
             
             _audio.UpdateTitle(request.Title);
             _audio.UpdateDescription(request.Description);
-            _audio.UpdatePublicity(request.IsPublic ?? false);
+            _audio.UpdateVisibility(request.Visibility ?? Visibility.Unlisted);
             
             return this;
         }
@@ -111,9 +112,9 @@ namespace Audiochan.Core.Common.Builders
             return this;
         }
 
-        public AudioBuilder SetPublic(bool isPublic)
+        public AudioBuilder SetVisibility(Visibility visibility)
         {
-            _audio.UpdatePublicity(isPublic);
+            _audio.UpdateVisibility(visibility);
             return this;
         }
 

--- a/server/src/Audiochan.Core/Common/Extensions/MappingExtensions/AudioMappingExtensions.cs
+++ b/server/src/Audiochan.Core/Common/Extensions/MappingExtensions/AudioMappingExtensions.cs
@@ -4,6 +4,7 @@ using System.Linq.Expressions;
 using Audiochan.Core.Common.Models.Responses;
 using Audiochan.Core.Common.Settings;
 using Audiochan.Core.Entities;
+using Audiochan.Core.Entities.Enums;
 using Audiochan.Core.Features.Audios;
 
 namespace Audiochan.Core.Common.Extensions.MappingExtensions
@@ -22,13 +23,13 @@ namespace Audiochan.Core.Common.Extensions.MappingExtensions
                 Picture = audio.Picture,
                 Uploaded = audio.Created.ToDateTimeUtc(),
                 Tags = audio.Tags.Select(t => t.Name).ToArray(),
-                IsPublic = audio.IsPublic,
+                Visibility = audio.Visibility,
                 FileExt = audio.FileExt,
                 FileSize = audio.FileSize,
                 LastModified = audio.LastModified.HasValue
                     ? audio.LastModified.Value.ToDateTimeUtc()
                     : null,
-                PrivateKey = audio.IsPublic ? null : audio.PrivateKey,
+                PrivateKey = audio.Visibility == Visibility.Private ? audio.PrivateKey : null,
                 AudioUrl =
                     $"https://{options.Audio.Bucket}.s3.amazonaws.com/{options.Audio.Container}/{audio.UploadId + audio.FileExt}",
                 Author = new MetaAuthorDto
@@ -49,7 +50,7 @@ namespace Audiochan.Core.Common.Extensions.MappingExtensions
                 Duration = audio.Duration,
                 Picture = audio.Picture,
                 Uploaded = audio.Created.ToDateTimeUtc(),
-                IsPublic = audio.IsPublic,
+                Visibility = audio.Visibility,
                 AudioUrl =
                     $"https://{options.Audio.Bucket}.s3.amazonaws.com/{options.Audio.Container}/{audio.UploadId + audio.FileExt}",
                 Author = new MetaAuthorDto

--- a/server/src/Audiochan.Core/Common/Extensions/QueryableExtensions/AudioQueryableExtensions.cs
+++ b/server/src/Audiochan.Core/Common/Extensions/QueryableExtensions/AudioQueryableExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using Audiochan.Core.Entities;
+using Audiochan.Core.Entities.Enums;
 using Microsoft.EntityFrameworkCore;
 
 namespace Audiochan.Core.Common.Extensions.QueryableExtensions
@@ -12,7 +13,7 @@ namespace Audiochan.Core.Common.Extensions.QueryableExtensions
                 .AsNoTracking()
                 .Include(a => a.Tags)
                 .Include(a => a.User)
-                .Where(a => a.UserId == currentUserId || a.IsPublic);
+                .Where(a => a.UserId == currentUserId || a.Visibility == Visibility.Public);
         }
 
         public static IQueryable<Audio> BaseDetailQueryable(this IQueryable<Audio> dbSet, string privateKey = "",
@@ -22,7 +23,9 @@ namespace Audiochan.Core.Common.Extensions.QueryableExtensions
                 .AsNoTracking()
                 .Include(a => a.Tags)
                 .Include(a => a.User)
-                .Where(a => a.UserId == currentUserId || a.IsPublic || a.PrivateKey == privateKey && !a.IsPublic);
+                .Where(a => a.UserId == currentUserId 
+                            || a.Visibility != Visibility.Private 
+                            || a.PrivateKey == privateKey && a.Visibility == Visibility.Private);
         }
     }
 }

--- a/server/src/Audiochan.Core/Common/Models/Requests/AudioAbstractRequest.cs
+++ b/server/src/Audiochan.Core/Common/Models/Requests/AudioAbstractRequest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Audiochan.Core.Entities.Enums;
 
 namespace Audiochan.Core.Common.Models.Requests
 {
@@ -6,7 +7,7 @@ namespace Audiochan.Core.Common.Models.Requests
     {
         public string Title { get; init; }
         public string Description { get; init; }
-        public bool? IsPublic { get; init; }
+        public Visibility? Visibility { get; init; }
         public List<string> Tags { get; init; } = new();
     }
 }

--- a/server/src/Audiochan.Core/Entities/Audio.cs
+++ b/server/src/Audiochan.Core/Entities/Audio.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using Audiochan.Core.Common.Extensions;
 using Audiochan.Core.Entities.Base;
+using Audiochan.Core.Entities.Enums;
 
 namespace Audiochan.Core.Entities
 {
@@ -22,7 +21,7 @@ namespace Audiochan.Core.Entities
         public long FileSize { get; set; }
         public string FileExt { get; set; }
         public string Picture { get; set; }
-        public bool IsPublic { get; set; }
+        public Visibility Visibility { get; set; }
         public string PrivateKey { get; set; }
         public string UserId { get; set; }
         public User User { get; set; }
@@ -40,17 +39,23 @@ namespace Audiochan.Core.Entities
                 this.Description = description;
         }
 
-        public void UpdatePublicity(bool isPublic)
+        public void UpdateVisibility(Visibility visibility)
         {
-            this.IsPublic = isPublic;
+            if (this.Visibility != visibility)
+            {
+                if (visibility == Visibility.Private)
+                {
+                    this.GenerateNewPrivateKey();
+                }
+                else if (this.Visibility == Visibility.Private)
+                {
+                    this.PrivateKey = null;
+                }
 
-            if (!isPublic && string.IsNullOrWhiteSpace(this.PrivateKey))
-                this.GenerateNewPrivateKey();
-
-            if (isPublic)
-                this.PrivateKey = null;
+                this.Visibility = visibility;
+            }
         }
-
+        
         public void GenerateNewPrivateKey()
         {
             this.PrivateKey = Guid.NewGuid().ToString("N");

--- a/server/src/Audiochan.Core/Features/Audios/AudioDetailViewModel.cs
+++ b/server/src/Audiochan.Core/Features/Audios/AudioDetailViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Audiochan.Core.Common.Models.Responses;
+using Audiochan.Core.Entities.Enums;
 
 namespace Audiochan.Core.Features.Audios
 {
@@ -8,7 +9,7 @@ namespace Audiochan.Core.Features.Audios
         public string Id { get; init; }
         public string Title { get; init; }
         public string Description { get; init; }
-        public bool IsPublic { get; init; }
+        public Visibility Visibility { get; init; }
         public string PrivateKey { get; init; }
         public string[] Tags { get; init; }
         public int Duration { get; init; }

--- a/server/src/Audiochan.Core/Features/Audios/AudioViewModel.cs
+++ b/server/src/Audiochan.Core/Features/Audios/AudioViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Audiochan.Core.Common.Models.Responses;
+using Audiochan.Core.Entities.Enums;
 
 namespace Audiochan.Core.Features.Audios
 {
@@ -7,7 +8,7 @@ namespace Audiochan.Core.Features.Audios
     {
         public string Id { get; init; }
         public string Title { get; init; }
-        public bool IsPublic { get; init; }
+        public Visibility Visibility { get; init; }        
         public int Duration { get; init; }
         public string Picture { get; init; }
         public DateTime Uploaded { get; init; }

--- a/server/src/Audiochan.Core/Features/Audios/GetAudioFeed/GetAudioFeedRequest.cs
+++ b/server/src/Audiochan.Core/Features/Audios/GetAudioFeed/GetAudioFeedRequest.cs
@@ -41,8 +41,8 @@ namespace Audiochan.Core.Features.Audios.GetAudioFeed
             return await _dbContext.Audios
                 .BaseListQueryable(request.UserId)
                 .Where(a => followedIds.Contains(a.UserId))
+                .OrderByDescending(a => a.Created)
                 .ProjectToList(_storageSettings)
-                .OrderByDescending(a => a.Uploaded)
                 .PaginateAsync(cancellationToken: cancellationToken);
         }
     }

--- a/server/src/Audiochan.Core/Features/Audios/GetAudioList/GetAudioListRequest.cs
+++ b/server/src/Audiochan.Core/Features/Audios/GetAudioList/GetAudioListRequest.cs
@@ -8,6 +8,7 @@ using Audiochan.Core.Common.Interfaces;
 using Audiochan.Core.Common.Models.Interfaces;
 using Audiochan.Core.Common.Models.Responses;
 using Audiochan.Core.Common.Settings;
+using Audiochan.Core.Entities.Enums;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -42,7 +43,7 @@ namespace Audiochan.Core.Features.Audios.GetAudioList
             var (dateTime, id) = CursorHelpers.DecodeCursor(request.Cursor);
 
             var queryable = _dbContext.Audios
-                .BaseListQueryable(currentUserId);
+                .Where(a => a.Visibility == Visibility.Public);
 
             if (dateTime.HasValue && !string.IsNullOrWhiteSpace(id))
             {

--- a/server/src/Audiochan.Core/Features/Audios/UpdateAudio/UpdateAudioRequest.cs
+++ b/server/src/Audiochan.Core/Features/Audios/UpdateAudio/UpdateAudioRequest.cs
@@ -70,8 +70,8 @@ namespace Audiochan.Core.Features.Audios.UpdateAudio
             audio.UpdateTitle(request.Title);
             audio.UpdateDescription(request.Description);
 
-            if (request.IsPublic.HasValue)
-                audio.UpdatePublicity(request.IsPublic.GetValueOrDefault());
+            if (request.Visibility.HasValue)
+                audio.UpdateVisibility(request.Visibility.Value);
 
             _dbContext.Audios.Update(audio);
             await _dbContext.SaveChangesAsync(cancellationToken);

--- a/server/src/Audiochan.Core/Features/Users/GetUserAudios/GetUserAudiosRequest.cs
+++ b/server/src/Audiochan.Core/Features/Users/GetUserAudios/GetUserAudiosRequest.cs
@@ -42,6 +42,7 @@ namespace Audiochan.Core.Features.Users.GetUserAudios
             return await _dbContext.Audios
                 .BaseListQueryable(currentUserId)
                 .Where(a => a.User.UserName == request.Username.ToLower())
+                .OrderByDescending(a => a.Created)
                 .ProjectToList(_storageSettings)
                 .PaginateAsync(request, cancellationToken);
         }

--- a/server/src/Audiochan.Infrastructure/Persistence/ApplicationDbSeeder.cs
+++ b/server/src/Audiochan.Infrastructure/Persistence/ApplicationDbSeeder.cs
@@ -4,6 +4,7 @@ using Audiochan.Core.Common.Builders;
 using Audiochan.Core.Common.Constants;
 using Audiochan.Core.Common.Interfaces;
 using Audiochan.Core.Entities;
+using Audiochan.Core.Entities.Enums;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using NodaTime;
@@ -47,7 +48,7 @@ namespace Audiochan.Infrastructure.Persistence
                     .AddDuration(388)
                     .AddUser(user)
                     .AddTags(await tagRepository.GetListAsync(new[] {"chillout", "lucid-dreams"}))
-                    .SetPublic(true)
+                    .SetVisibility(Visibility.Public)
                     .BuildAsync();
                 
                 var audio2 = await new AudioBuilder()
@@ -58,7 +59,7 @@ namespace Audiochan.Infrastructure.Persistence
                     .AddDuration(194)
                     .AddUser(user)
                     .AddTags(await tagRepository.GetListAsync(new[] {"newgrounds", "piano", "rave"}))
-                    .SetPublic(true)
+                    .SetVisibility(Visibility.Public)
                     .BuildAsync();
                 
                 var audio3 = await new AudioBuilder()
@@ -69,7 +70,7 @@ namespace Audiochan.Infrastructure.Persistence
                     .AddDuration(45)
                     .AddUser(user)
                     .AddTags(await tagRepository.GetListAsync(new[] {"happy", "anime", "hardcore", "nightcore"}))
-                    .SetPublic(true)
+                    .SetVisibility(Visibility.Public)
                     .BuildAsync();
                 
                 var audio4 = await new AudioBuilder()
@@ -80,7 +81,7 @@ namespace Audiochan.Infrastructure.Persistence
                     .AddDuration(164)
                     .AddUser(user)
                     .AddTags(await tagRepository.GetListAsync(new[] {"hard-dance"}))
-                    .SetPublic(false)
+                    .SetVisibility(Visibility.Unlisted)
                     .BuildAsync();
                 
                 var audio5 = await new AudioBuilder()
@@ -91,7 +92,7 @@ namespace Audiochan.Infrastructure.Persistence
                     .AddDuration(219)
                     .AddUser(user)
                     .AddTags(await tagRepository.GetListAsync(new[] {"vocals"}))
-                    .SetPublic(false)
+                    .SetVisibility(Visibility.Private)
                     .BuildAsync();
 
                 await context.Audios.AddRangeAsync(audio1, audio2, audio3, audio4, audio5);

--- a/server/src/Audiochan.Infrastructure/Persistence/Migrations/20210507065850_SetVisibility.Designer.cs
+++ b/server/src/Audiochan.Infrastructure/Persistence/Migrations/20210507065850_SetVisibility.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Audiochan.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -10,9 +11,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Audiochan.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210507065850_SetVisibility")]
+    partial class SetVisibility
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/src/Audiochan.Infrastructure/Persistence/Migrations/20210507065850_SetVisibility.cs
+++ b/server/src/Audiochan.Infrastructure/Persistence/Migrations/20210507065850_SetVisibility.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Audiochan.Infrastructure.Persistence.Migrations
+{
+    public partial class SetVisibility : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "is_public",
+                table: "audios");
+
+            migrationBuilder.AddColumn<int>(
+                name: "visibility",
+                table: "audios",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "visibility",
+                table: "audios");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "is_public",
+                table: "audios",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+    }
+}

--- a/server/src/Audiochan.Infrastructure/Search/DatabaseSearchService.cs
+++ b/server/src/Audiochan.Infrastructure/Search/DatabaseSearchService.cs
@@ -45,6 +45,7 @@ namespace Audiochan.Infrastructure.Search
                     .ILike(a.Title, $"%{searchTerm.Trim()}%"));
 
             var result = await queryable
+                .OrderByDescending(a => a.Created)
                 .ProjectToList(_storageSettings)
                 .PaginateAsync(page, limit, cancellationToken);
 

--- a/server/tests/Audiochan.IntegrationTests/Features/Audios/CreateAudioTests.cs
+++ b/server/tests/Audiochan.IntegrationTests/Features/Audios/CreateAudioTests.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Audiochan.Core.Common.Helpers;
+using Audiochan.Core.Entities.Enums;
 using Audiochan.Core.Features.Audios.CreateAudio;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
@@ -72,7 +73,7 @@ namespace Audiochan.IntegrationTests.Features.Audios
             created.Tags.Should().Contain(x => x.Name == "apples");
             created.Tags.Should().Contain(x => x.Name == "oranges");
             created.Tags.Should().Contain(x => x.Name == "banana");
-            created.IsPublic.Should().BeFalse();
+            created.Visibility.Should().Be(Visibility.Unlisted);
             created.PrivateKey.Should().NotBeEmpty();
             created.UserId.Should().Be(userId);
         }

--- a/server/tests/Audiochan.IntegrationTests/Features/Audios/GetAudioTests.cs
+++ b/server/tests/Audiochan.IntegrationTests/Features/Audios/GetAudioTests.cs
@@ -100,6 +100,22 @@ namespace Audiochan.IntegrationTests.Features.Audios
         }
 
         [Fact]
+        public async Task ShouldGetAudio_WhenAudioIsUnlisted_AsAnotherUser()
+        {
+            var (ownerId, _) = await _fixture.RunAsAdministratorAsync();
+            var audio = await new AudioBuilder()
+                .UseTestDefaults(ownerId)
+                .SetVisibility(Visibility.Unlisted)
+                .BuildAsync();
+            await _fixture.InsertAsync(audio);
+
+            await _fixture.RunAsDefaultUserAsync();
+            var result = await _fixture.SendAsync(new GetAudioRequest(audio.Id));
+
+            result.Should().NotBeNull();
+        }
+
+        [Fact]
         public async Task ShouldGetAudio()
         {
             // Assign

--- a/server/tests/Audiochan.IntegrationTests/Features/Audios/GetAudioTests.cs
+++ b/server/tests/Audiochan.IntegrationTests/Features/Audios/GetAudioTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Audiochan.Core.Common.Builders;
 using Audiochan.Core.Common.Helpers;
+using Audiochan.Core.Entities.Enums;
 using Audiochan.Core.Features.Audios;
 using Audiochan.Core.Features.Audios.CreateAudio;
 using Audiochan.Core.Features.Audios.GetAudio;
@@ -46,7 +47,7 @@ namespace Audiochan.IntegrationTests.Features.Audios
             var (adminId, _) = await _fixture.RunAsAdministratorAsync();
             var audio = await new AudioBuilder()
                 .UseTestDefaults(adminId, Guid.NewGuid() + ".mp3")
-                .SetPublic(false)
+                .SetVisibility(Visibility.Private)
                 .BuildAsync();
             await _fixture.InsertAsync(audio);
 
@@ -68,7 +69,7 @@ namespace Audiochan.IntegrationTests.Features.Audios
             var privateKey = "test";
             var audio = await new AudioBuilder()
                 .UseTestDefaults(ownerId)
-                .SetPublic(false)
+                .SetVisibility(Visibility.Private)
                 .OverwritePrivateKey(privateKey)
                 .BuildAsync();
             await _fixture.InsertAsync(audio);
@@ -87,7 +88,7 @@ namespace Audiochan.IntegrationTests.Features.Audios
             var privateKey = "test";
             var audio = await new AudioBuilder()
                 .UseTestDefaults(ownerId)
-                .SetPublic(false)
+                .SetVisibility(Visibility.Private)
                 .OverwritePrivateKey(privateKey)
                 .BuildAsync();
             await _fixture.InsertAsync(audio);
@@ -112,7 +113,6 @@ namespace Audiochan.IntegrationTests.Features.Audios
                 Duration = 100,
                 FileSize = 100,
                 Tags = new List<string> {"apples", "oranges"},
-                IsPublic = true
             });
 
             // Act
@@ -126,6 +126,7 @@ namespace Audiochan.IntegrationTests.Features.Audios
             result.Tags.Length.Should().Be(2);
             result.Tags.Should().Contain("apples");
             result.Tags.Should().Contain("oranges");
+            result.Visibility.Should().Be(Visibility.Unlisted);
         }
     }
 }

--- a/server/tests/Audiochan.IntegrationTests/Features/Audios/GetAudiosTests.cs
+++ b/server/tests/Audiochan.IntegrationTests/Features/Audios/GetAudiosTests.cs
@@ -1,4 +1,10 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Audiochan.Core.Common.Builders;
+using Audiochan.Core.Entities.Enums;
+using Audiochan.Core.Features.Audios.GetAudioList;
+using Audiochan.UnitTests;
+using FluentAssertions;
+using Xunit;
 
 namespace Audiochan.IntegrationTests.Features.Audios
 {
@@ -10,6 +16,42 @@ namespace Audiochan.IntegrationTests.Features.Audios
         public GetAudiosTests(SliceFixture fixture)
         {
             _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task ShouldNotGetUnlistedOrPrivateAudios()
+        {
+            var (ownerId, _) = await _fixture.RunAsAdministratorAsync();
+            
+            for (var i = 0; i < 10; i++)
+            {
+                var audioBuilder = new AudioBuilder()
+                    .UseTestDefaults(ownerId)
+                    .SetVisibility(Visibility.Public);
+
+                switch (i)
+                {
+                    case 6:
+                    case 7:
+                        audioBuilder = audioBuilder.SetVisibility(Visibility.Unlisted);
+                        break;
+                    case 8:
+                    case 9:
+                        audioBuilder = audioBuilder.SetVisibility(Visibility.Private);
+                        break;
+                }
+
+                var audio = await audioBuilder.BuildAsync();
+
+                await _fixture.InsertAsync(audio);
+            }
+            
+            var result = await _fixture.SendAsync(new GetAudioListRequest());
+
+            result.Should().NotBeNull();
+            result.Items.Should().NotBeNull();
+            result.Items.Count.Should().BeGreaterThan(0);
+            result.Items.Count.Should().Be(6);
         }
     }
 }

--- a/server/tests/Audiochan.IntegrationTests/Features/Search/SearchAudioQueryTests.cs
+++ b/server/tests/Audiochan.IntegrationTests/Features/Search/SearchAudioQueryTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Audiochan.Core.Common.Builders;
 using Audiochan.Core.Common.Helpers;
+using Audiochan.Core.Entities.Enums;
 using Audiochan.Core.Features.Audios.CreateAudio;
 using Audiochan.Core.Features.Audios.SearchAudios;
 using Audiochan.UnitTests;
@@ -41,7 +42,7 @@ namespace Audiochan.IntegrationTests.Features.Search
                 var audio = await new AudioBuilder()
                     .UseTestDefaults(userId)
                     .AddTitle(title)
-                    .SetPublic(true)
+                    .SetVisibility(Visibility.Public)
                     .BuildAsync();
                 await _fixture.InsertAsync(audio);
             }
@@ -80,7 +81,7 @@ namespace Audiochan.IntegrationTests.Features.Search
                     Duration = 100,
                     FileSize = 100,
                     Tags = tags,
-                    IsPublic = true
+                    Visibility = Visibility.Public
                 });
             }
 

--- a/web/src/components/AudioPlayer/types.ts
+++ b/web/src/components/AudioPlayer/types.ts
@@ -1,6 +1,6 @@
 export type AudioPlayerItem = {
   queueId: string;
-  audioId: number;
+  audioId: string;
   title: string;
   artist: string;
   artistId: string;

--- a/web/src/components/form/VisibilityInput.tsx
+++ b/web/src/components/form/VisibilityInput.tsx
@@ -1,0 +1,15 @@
+import { AddIcon } from "@chakra-ui/icons";
+import { ButtonGroup, Button, IconButton } from "@chakra-ui/react";
+import React from "react";
+
+interface VisibilityInputProps {}
+
+const VisibilityInput: React.FC<VisibilityInputProps> = (props) => {
+  return (
+    <ButtonGroup size="sm" isAttached variant="outline">
+      <Button>Public</Button>
+      <Button>Unlisted</Button>
+      <Button>Private</Button>
+    </ButtonGroup>
+  );
+};

--- a/web/src/features/audio/components/AudioUploading.tsx
+++ b/web/src/features/audio/components/AudioUploading.tsx
@@ -20,11 +20,10 @@ import {
 
 interface AudioUploadingProps {
   file: File | null;
-  isPublic: boolean;
 }
 
 const AudioUploading: React.FC<AudioUploadingProps> = (props) => {
-  const { file, isPublic } = props;
+  const { file } = props;
 
   const { mutateAsync: createAudio } = useCreateAudio();
 
@@ -47,7 +46,7 @@ const AudioUploading: React.FC<AudioUploadingProps> = (props) => {
           duration: Math.round(audioDuration),
           fileSize: file.size,
           tags: [],
-          isPublic: isPublic,
+          visibility: "unlisted",
         });
         setAudioId(audio.id);
       }

--- a/web/src/features/audio/components/Details.tsx
+++ b/web/src/features/audio/components/Details.tsx
@@ -177,7 +177,9 @@ const AudioDetails: React.FC<AudioDetailProps> = ({ audio }) => {
             <Spacer />
             <VStack spacing={2} alignItems="normal" textAlign="right">
               <Box color={secondaryColor}>{audioDurationFormatted}</Box>
-              {!audio.isPublic && <Badge>PRIVATE</Badge>}
+              {audio.visibility !== "public" && (
+                <Badge textTransform="uppercase">{audio.visibility}</Badge>
+              )}
             </VStack>
           </Flex>
           {audio.tags && (

--- a/web/src/features/audio/components/Edit.tsx
+++ b/web/src/features/audio/components/Edit.tsx
@@ -25,6 +25,9 @@ import {
   FormHelperText,
   ListItem,
   UnorderedList,
+  Radio,
+  RadioGroup,
+  Stack,
 } from "@chakra-ui/react";
 import { DeleteIcon } from "@chakra-ui/icons";
 import React, { useMemo, useState } from "react";
@@ -49,7 +52,7 @@ function mapAudioToModifyInputs(audio: AudioDetail): AudioRequest {
     title: audio.title,
     description: audio.description,
     tags: audio.tags,
-    isPublic: audio.isPublic,
+    visibility: audio.visibility,
   };
 }
 
@@ -147,15 +150,17 @@ const AudioEditModal: React.FC<AudioEditProps> = ({
               error={errors.tags}
               disabled={isSubmitting || deleting}
             />
-            <InputCheckbox
-              name="isPublic"
-              onChange={() => setFieldValue("isPublic", !values.isPublic)}
-              value={values.isPublic ?? false}
-              required
-              error={errors.isPublic}
-              toggleSwitch
-              label="Public"
-            />
+            <RadioGroup
+              name="visibility"
+              value={values.visibility || "public"}
+              onChange={(value) => setFieldValue("visibility", value)}
+            >
+              <Stack spacing={4} direction="row">
+                <Radio value="public">Public</Radio>
+                <Radio value="unlisted">Unlisted</Radio>
+                <Radio value="private">Private</Radio>
+              </Stack>
+            </RadioGroup>
             <Flex marginY={4}>
               <Box>
                 <Popover>

--- a/web/src/features/audio/components/List/ListItem.tsx
+++ b/web/src/features/audio/components/List/ListItem.tsx
@@ -85,7 +85,9 @@ const AudioListItem: React.FC<AudioListItemProps> = ({
         </Flex>
         <Flex flex="1" justify="flex-end">
           <Stack direction="column" spacing={1} textAlign="right">
-            {!audio.isPublic && <Badge>PRIVATE</Badge>}
+            {audio.visibility !== "public" && (
+              <Badge textTransform="uppercase">{audio.visibility}</Badge>
+            )}
           </Stack>
         </Flex>
       </Flex>

--- a/web/src/features/audio/components/Pages/AudioListPage.tsx
+++ b/web/src/features/audio/components/Pages/AudioListPage.tsx
@@ -26,7 +26,7 @@ export default function AudioListPage(props: AudioListPageProps) {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useAudioList({ ...listFilter }, 1, {
+  } = useAudioList({ ...listFilter }, undefined, {
     staleTime: 1000,
     initialData: initialPage && {
       pages: [initialPage],

--- a/web/src/features/audio/components/Pages/AudioUploadPage.tsx
+++ b/web/src/features/audio/components/Pages/AudioUploadPage.tsx
@@ -5,23 +5,14 @@ import AudioUploading from "../AudioUploading";
 
 export default function AudioUploadPage() {
   const [file, setFile] = useState<File | null>(null);
-  const [isPublic, setPublic] = useState(false);
 
   if (file) {
-    return <AudioUploading file={file} isPublic={isPublic} />;
+    return <AudioUploading file={file} />;
   }
 
   return (
     <Box>
       <AudioUploadDropzone onUpload={(file) => setFile(file)} />
-      <Flex justifyContent="center">
-        <Checkbox
-          checked={isPublic}
-          onChange={() => setPublic((prev) => !prev)}
-        >
-          Set audio to public after upload.
-        </Checkbox>
-      </Flex>
     </Box>
   );
 }

--- a/web/src/features/audio/hooks/mutations/useAddAudioPicture.ts
+++ b/web/src/features/audio/hooks/mutations/useAddAudioPicture.ts
@@ -3,7 +3,7 @@ import { useAuth } from '~/contexts/AuthContext';
 import api from '~/utils/api'
 
 
-export function useAddAudioPicture(id: number) {
+export function useAddAudioPicture(id: string) {
   const queryClient = useQueryClient();
   const { accessToken } = useAuth();
   const uploadArtwork = async (data: string) => {

--- a/web/src/features/audio/hooks/mutations/useEditAudio.ts
+++ b/web/src/features/audio/hooks/mutations/useEditAudio.ts
@@ -4,7 +4,7 @@ import api from '~/utils/api';
 import { AudioDetail } from '../../types';
 
 
-export function useEditAudio(id: number) {
+export function useEditAudio(id: string) {
   const queryClient = useQueryClient();
   const { accessToken } = useAuth();
   const updateAudio = async (input: object) => {

--- a/web/src/features/audio/hooks/mutations/useRemoveAudio.ts
+++ b/web/src/features/audio/hooks/mutations/useRemoveAudio.ts
@@ -3,7 +3,7 @@ import { useAuth } from '~/contexts/AuthContext';
 import api from '~/utils/api';
 
 
-export function useRemoveAudio(id: number) {
+export function useRemoveAudio(id: string) {
   const queryClient = useQueryClient();
   const { accessToken } = useAuth();
   const removeAudio = async () => await api.delete(`audios/${id}`, { accessToken });

--- a/web/src/features/audio/schemas.ts
+++ b/web/src/features/audio/schemas.ts
@@ -1,3 +1,4 @@
+import { yupToFormErrors } from 'formik';
 import {
   array,
   boolean,
@@ -21,23 +22,7 @@ export const editAudioSchema: SchemaOf<AudioRequest> = object().shape({
     .max(10, validationMessages.max("Tags", 10))
     .ensure()
     .defined(),
-  isPublic: boolean()
-    .defined()
-}).defined();
-
-export const uploadAudioSchema: SchemaOf<AudioRequest> = object().shape({
-  title: string()
-    .max(30, validationMessages.max("Title", 30))
-    .ensure()
-    .defined(),
-  description: string()
-    .max(500, validationMessages.max("Description", 500))
-    .ensure()
-    .defined(),
-  tags: array(string())
-    .max(10, validationMessages.max("Tags", 10))
-    .ensure()
-    .defined(),
-  isPublic: boolean()
-    .defined()
+  visibility: string()
+    .required(validationMessages.required("Visiblity"))
+    .oneOf(['public', 'unlisted', 'private'])
 }).defined();

--- a/web/src/features/audio/types.ts
+++ b/web/src/features/audio/types.ts
@@ -7,7 +7,7 @@ export type Visibility = 'unlisted' | 'public' | 'private'
 export type Audio = {
   id: string;
   title: string;
-  isPublic: boolean;
+  visibility: string;
   duration: number;
   picture?: string;
   uploaded: string;
@@ -19,7 +19,7 @@ export type AudioDetail = {
   id: string;
   title: string;
   description?: string;
-  isPublic: boolean;
+  visibility: string;
   privateKey?: string;
   tags: string[];
   duration: number;
@@ -36,7 +36,7 @@ export interface AudioRequest {
   title: string;
   description?: string;
   tags: string[];
-  isPublic?: boolean;
+  visibility: string;
 };
 
 export interface CreateAudioRequest extends AudioRequest {


### PR DESCRIPTION
This feature adds visibility for audio posts. A post can either be public, unlisted, or private.

Public - Can be viewed by anyone and will be listed on public lists.
Unlisted - Can only be viewed when the user access it directly.
Private - Can only be viewed with a private key.

TODO:
- [ ] Create tests